### PR TITLE
Change "Arkivera" to "Arkiv" when it's a noun

### DIFF
--- a/po/sv/ark.po
+++ b/po/sv/ark.po
@@ -38,7 +38,7 @@ msgstr "stefan.asserhall@bredband.net"
 #, kde-format
 msgctxt "Noun, not a verb. Top level menu item, i.e. like File"
 msgid "&Archive"
-msgstr "&Arkivera"
+msgstr "&Arkiv"
 
 #: app/batchextract.cpp:103 app/batchextract.cpp:167
 #, kde-format
@@ -477,7 +477,7 @@ msgstr ""
 #, kde-format
 msgctxt "Default name of a newly-created multi-file archive"
 msgid "Archive"
-msgstr "Arkivera"
+msgstr "Arkiv"
 
 #. i18n: ectx: label, entry (showEncryptionWarning), group (General)
 #: kerfuffle/ark.kcfg:9
@@ -1392,7 +1392,7 @@ msgstr "&Arkivera"
 #: part/ark_part.rc:15
 #, kde-format
 msgid "&File"
-msgstr "&Arkiv"
+msgstr "&Fil"
 
 #. i18n: ectx: Menu (settings)
 #: part/ark_part.rc:29


### PR DESCRIPTION
The Swedish word for the noun "archive" is "arkiv." The Swedish verb is "att arkivera" ("to archive"). In the translation this difference is not respected, only the verb is used. Also changes the word "File" from "Arkiv" to "Fil", since that should be correct.